### PR TITLE
JPA full model loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 
 .idea
+/models/ivoa/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 
 .idea
 /models/ivoa/bin/
+/tools/gradletooling/gradle-plugin/bin/

--- a/models/ivoa/build.gradle.kts
+++ b/models/ivoa/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("net.ivoa.vo-dml.vodmltools") version "0.3.5"
+    id("net.ivoa.vo-dml.vodmltools") version "0.3.6"
 //    id ("com.diffplug.spotless") version "5.17.1"
     `maven-publish`
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
@@ -31,7 +31,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
 
-    implementation("org.slf4j:slf4j-api:1.7.32")
+    implementation("org.slf4j:slf4j-api:1.7.36")
     testRuntimeOnly("ch.qos.logback:logback-classic:1.2.3")
 
     testImplementation("org.apache.derby:derby:10.14.2.0")

--- a/runtime/java/build.gradle.kts
+++ b/runtime/java/build.gradle.kts
@@ -6,14 +6,14 @@ plugins {
     signing
 }
 group = "org.javastro.ivoa.vo-dml"
-version = "0.1.1"
+version = "0.1.2"
 
 
 dependencies {
 //    xjcPlugins("net.codesup.util:jaxb2-rich-contract-plugin:2.1.0")
  //   implementation("jakarta.persistence:jakarta.persistence-api:3.0.0") // more modern, but perhaps not quite ready
     implementation("javax.persistence:javax.persistence-api:2.2")
-    implementation("org.slf4j:slf4j-api:1.7.32")
+    implementation("org.slf4j:slf4j-api:1.7.36")
     testRuntimeOnly("ch.qos.logback:logback-classic:1.2.3")
 }
 

--- a/runtime/java/src/main/java/org/ivoa/vodml/nav/JPACollectionTraverser.java
+++ b/runtime/java/src/main/java/org/ivoa/vodml/nav/JPACollectionTraverser.java
@@ -1,0 +1,11 @@
+package org.ivoa.vodml.nav;
+/*
+ * Created on 29/03/2022 by Paul Harrison (paul.harrison@manchester.ac.uk).
+ */
+
+/**
+ * Interface to walk collections in order to force loading by JPA.
+ */
+public interface JPACollectionTraverser {
+   void walkCollections();
+}

--- a/tools/JavaCodeGeneration.md
+++ b/tools/JavaCodeGeneration.md
@@ -80,6 +80,9 @@ A static function to create a suitable JAXBContext
 ```java
 JAXBContext jc = MyModel.contextFactory();
 ```
+In general collections are marked for lazy loading, and as a convenience there is a `walkCollections()`
+method generated that will do a deep walk of all the collections in a particular type, whcih will force the loading.
+
 
 #### Functions for adding content
 For each of the concrete objectTypes in the model there is 

--- a/tools/ReadMe.md
+++ b/tools/ReadMe.md
@@ -1,4 +1,4 @@
-Using the VO-DML Gradle Plugin 0.3.5
+Using the VO-DML Gradle Plugin 0.3.6
 ===================================
 
 The aim of this plugin is to process VO-DML models to produce documentation and source code that
@@ -19,7 +19,7 @@ as below.
 
 ```kotlin
 plugins {
-    id("net.ivoa.vo-dml.vodmltools") version "0.3.5"
+    id("net.ivoa.vo-dml.vodmltools") version "0.3.6"
 }
 ```
 3. create the  binding files for the model (see below in the configuration section) 
@@ -121,5 +121,6 @@ _TODO - there is still some information in the [README.txt](./README.txt) file t
 * 0.3.3 bugfix for html document generation
 * 0.3.4 the plugin now saves VO-DML and binding files to the created jar and then uses them if they are in dependency tree.
 * 0.3.5 better working in the inherited data-model case.
+* 0.3.6 JPA EntityGraphs
 
 ## Information for [developers of the plugin itself](./Developing.md)

--- a/tools/gradletooling/TODO.md
+++ b/tools/gradletooling/TODO.md
@@ -6,14 +6,19 @@ VODML Tooling TODO
 * used twice in composition schematron rule should not necessarily matter
 * clear up array intentions in multiplicity
 * should only be a note for references multiplicity...aggregation
+* unique constraint in composition...- would result in Set as the container.
+* the rdb and xml schemas produced by the xslt are unlikely to match the java generated ones exactly - they need to be updated.
 
 
 # gradle plugin
 
 * ~~get binding files from dependent jars~~
-* write some documentation
+* write a usage note
 * ~~publish in gradle repository~~
 * ~~can remove all the ant stuff - including the libs and schematron dirs~~
+* generate python
+* integrate with the model mapping in VOT.
+
 
 # Java Production
 
@@ -31,6 +36,7 @@ VODML Tooling TODO
   * ~~idrefs referred to objects are not being output - http://stackoverflow.com/questions/12914382/marshalling-unmarshalling-fields-to-tag-with-attributes-using-jaxb~~
   * make the subsets create substitution group xml (i.e. have elements rather than xsi:type)
   * don't allow to add to content something that is a reference? 
+  * should dtypes be root elements? better to add to the modelElement....
   * not dealing with something that is a composition and also a reference 
     * should this be explicitly dis-allowed?
     * should back-references be put in automatically?
@@ -38,10 +44,13 @@ VODML Tooling TODO
   * embedded are not nullable - means that datatype with optional multiplicity is not handled well (i.e cannot be null!) https://hibernate.atlassian.net/browse/HHH-14818
     * see https://stackoverflow.com/questions/40979957/how-can-i-prevent-jpa-from-setting-an-embeddable-object-to-null-just-because-all?noredirect=1&lq=1 for the description of opposite
     * the way that this was worked around in proposalDM is to make the RealQuanity have nullable content - not ideal, but not too bad as unlikely to want to create a RealQuantity without both val and unit.
-    * https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#fetching-strategies-dynamic-fetching-entity-graph
+  * https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#fetching-strategies-dynamic-fetching-entity-graph - 
+    https://thorben-janssen.com/fix-multiplebagfetchexception-hibernate/
+    https://blog.jooq.org/no-more-multiplebagfetchexception-thanks-to-multiset-nested-collections/ - perhaps
 * STC
   * epoch - not really defined as something that is used properly
   * equinox in spaceframe (only used for a few..)
   * names a bit confusing...
   * concrete types - for a library?
   * polarization enum - not comprehensive - no L circular
+  * AstroCoordSystem - is a CoordSys and has a CoordSys

--- a/tools/gradletooling/TODO.md
+++ b/tools/gradletooling/TODO.md
@@ -34,7 +34,7 @@ VODML Tooling TODO
   * add constructor that misses out the optional attributes.
 * JAXB
   * ~~idrefs referred to objects are not being output - http://stackoverflow.com/questions/12914382/marshalling-unmarshalling-fields-to-tag-with-attributes-using-jaxb~~
-  * make the subsets create substitution group xml (i.e. have elements rather than xsi:type)
+  * make the subsets create substitution group xml (i.e. have elements rather than xsi:type) http://blog.bdoughan.com/2010/11/jaxb-and-inheritance-using-substitution.html
   * don't allow to add to content something that is a reference? 
   * should dtypes be root elements? better to add to the modelElement....
   * not dealing with something that is a composition and also a reference 

--- a/tools/gradletooling/gradle-plugin/bin/main/net/ivoa/vodml/gradle/plugin/VodmlDocTask.kt
+++ b/tools/gradletooling/gradle-plugin/bin/main/net/ivoa/vodml/gradle/plugin/VodmlDocTask.kt
@@ -37,23 +37,17 @@ import java.util.concurrent.TimeUnit
 
          vodmlFiles.forEach{
              val shortname = it.nameWithoutExtension
-             var outfile = docDir.file(shortname +".html")
-             Vodml2Html.doTransform(it.absoluteFile, outfile.get().asFile)
-             outfile = docDir.file(shortname +".graphml")
-             Vodml2Gml.doTransform(it.absoluteFile, emptyMap(), catalogFile.get().asFile, outfile.get().asFile)
-             outfile = docDir.file(shortname +"_desc.tex" )
-             val params = if (modelsToDocument.isPresent) mapOf("modelsToDocument" to modelsToDocument.get()) else emptyMap()
-             Vodml2Latex.doTransform(it.absoluteFile, params, catalogFile.get().asFile, outfile.get().asFile)
              logger.info("doing graphviz generation")
-             outfile = docDir.file(shortname +".gvd")
+             var outfile = docDir.file(shortname +".gvd")
              Vodml2Gvd.doTransform(it.absoluteFile, outfile.get().asFile)
+
              val proc = ProcessBuilder(listOf(
                  "dot",
                  "-Tcmapx",
                  "-o${shortname +".map"}",
-                  "-Tpng",
+                 "-Tpng",
                  "-o${shortname +".png"}",
-                  outfile.get().asFile.absolutePath
+                 outfile.get().asFile.absolutePath
              ))
                  .directory(docDir.get().asFile)
                  .redirectOutput(ProcessBuilder.Redirect.PIPE)
@@ -64,7 +58,17 @@ import java.util.concurrent.TimeUnit
 
              logger.info(proc.inputStream.bufferedReader().readText())
              if (proc.exitValue() != 0)
-                logger.error(proc.errorStream.bufferedReader().readText())
+                 logger.error(proc.errorStream.bufferedReader().readText())
+
+             outfile = docDir.file(shortname +".html")
+             Vodml2Html.doTransform(it.absoluteFile, mapOf("graphviz_png" to  shortname +".png",
+                                                            "graphviz_map" to docDir.file(shortname +".map").get().asFile.absolutePath),
+                       catalogFile.get().asFile, outfile.get().asFile)
+             outfile = docDir.file(shortname +".graphml")
+             Vodml2Gml.doTransform(it.absoluteFile, emptyMap(), catalogFile.get().asFile, outfile.get().asFile)
+             outfile = docDir.file(shortname +"_desc.tex" )
+             val params = if (modelsToDocument.isPresent) mapOf("modelsToDocument" to modelsToDocument.get()) else emptyMap()
+             Vodml2Latex.doTransform(it.absoluteFile, params, catalogFile.get().asFile, outfile.get().asFile)
 
          }
 

--- a/tools/gradletooling/gradle-plugin/bin/main/net/ivoa/vodml/gradle/plugin/VodmlExtension.kt
+++ b/tools/gradletooling/gradle-plugin/bin/main/net/ivoa/vodml/gradle/plugin/VodmlExtension.kt
@@ -24,7 +24,7 @@ open class VodmlExtension @Inject constructor(objects: ObjectFactory, layout: Pr
     override val defaultPackage = objects.property(String::class.java).convention("vodml.generated")
     override val generateEpisode = objects.property(Boolean::class.java).convention(false)
     override val bindingFiles = objects.fileCollection()
-    override val catalogFile = objects.fileProperty().convention(layout.projectDirectory.file("catalog.xml"))
+    override val catalogFile = objects.fileProperty()
     override val modelsToDocument: Property<String> = objects.property(String::class.java)
     override val vodslDir: DirectoryProperty = objects.directoryProperty().convention(layout.projectDirectory.dir("src/main/vodsl"))
     override val vodslFiles = objects.fileCollection()

--- a/tools/gradletooling/gradle-plugin/bin/main/net/ivoa/vodml/gradle/plugin/VodmlJavaTask.kt
+++ b/tools/gradletooling/gradle-plugin/bin/main/net/ivoa/vodml/gradle/plugin/VodmlJavaTask.kt
@@ -1,10 +1,16 @@
 package net.ivoa.vodml.gradle.plugin
 
+import org.apache.tools.ant.types.PatternSet
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.*
+import java.io.File
+import java.nio.file.Paths
+import java.util.jar.JarInputStream
+import javax.inject.Inject
 
 
 /*
@@ -12,8 +18,11 @@ import org.gradle.api.tasks.*
  * Created on 04/08/2021 by Paul Harrison (paul.harrison@manchester.ac.uk). 
  */
 
- open class VodmlJavaTask : DefaultTask()
+ open class VodmlJavaTask @Inject constructor(private val ao: ArchiveOperations) : DefaultTask()
  {
+
+
+
      @get:[InputDirectory PathSensitive(PathSensitivity.RELATIVE)]
      val vodmlDir: DirectoryProperty = project.objects.directoryProperty()
 
@@ -26,22 +35,77 @@ import org.gradle.api.tasks.*
      @get:InputFiles
      val bindingFiles: ConfigurableFileCollection = project.objects.fileCollection()
 
-     @get:InputFile
+     @get:InputFile @Optional
      val catalogFile: RegularFileProperty = project.objects.fileProperty()
 
      @TaskAction
-     fun doDocumentation() {
+     fun doGeneration() {
          logger.info("Generating Java for VO-DML files ${vodmlFiles.files.joinToString { it.name }}")
          logger.info("Looked in ${vodmlDir.get()}")
-
-         vodmlFiles.forEach{
-             val shortname = it.nameWithoutExtension
-             val outfile = javaGenDir.file(shortname +".javatrans.txt")
-             Vodml2Java.doTransform(it.absoluteFile, mapOf(
-                 "binding" to bindingFiles.files.joinToString(separator = ","){it.absolutePath},
-                 "output_root" to javaGenDir.get().asFile.absolutePath
-             ),
-                 catalogFile.get().asFile, outfile.get().asFile)
+         val externalModelJars = project.configurations.getByName("runtimeClasspath").files.filter (hasVodml)
+         logger.info("external models=${externalModelJars.joinToString { f->f.name }}")
+         val extBinding = externalModelJars.flatMap{ f ->
+             ao.zipTree(f).matching(org.gradle.api.tasks.util.PatternSet().include(bindingFileName(f))).files
          }
+         val allBinding  = bindingFiles.files.plus(extBinding)
+
+         val tmpdir = project.mkdir(Paths.get(project.buildDir.absolutePath,"tmp",))
+         val actualCatalog = if (catalogFile.isPresent) catalogFile.get().asFile
+                else createCatalog(project.file(Paths.get(tmpdir.absolutePath, "catalog.xml")),
+             vodmlFiles.files.plus (
+                 externalModelJars.flatMap{ f ->
+                     ao.zipTree(f).matching(org.gradle.api.tasks.util.PatternSet().include(vodmlFileName(f))).files
+                            }
+                     )
+         )
+
+
+         var index = 0;
+         vodmlFiles.forEach{  v ->
+             val shortname = v.nameWithoutExtension
+             val outfile = javaGenDir.file("$shortname.javatrans.txt")
+             Vodml2Java.doTransform(v.absoluteFile, mapOf(
+                 "binding" to allBinding.joinToString(separator = ","){it.absolutePath},
+                 "output_root" to javaGenDir.get().asFile.absolutePath,
+                 "isMain" to (if (index++ == 0 ) "True" else "False") // first is the Main
+             ),
+                 actualCatalog, outfile.get().asFile)
+         }
+     }
+     private val hasVodml = fun (f: File): Boolean {
+         val js = JarInputStream(f.inputStream())
+         return (js.manifest.mainAttributes.getValue("VODML-binding") ) != null //IMPL because of weird map of maps no contains
+     }
+
+     private val bindingFileName = fun (f: File): String {
+         val js = JarInputStream(f.inputStream())
+         return (js.manifest.mainAttributes.getValue("VODML-binding") )
+     }
+     private val vodmlFileName = fun (f: File): String {
+         val js = JarInputStream(f.inputStream())
+         return (js.manifest.mainAttributes.getValue("VODML-source") )
+     }
+
+     private fun createCatalog(cat : File, v: Iterable<File> ): File {
+         cat.bufferedWriter().use { out ->
+             out.write(
+                 """
+                     <?xml version="1.0"?>
+                     <catalog  xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+                        <group  prefer="system"  >
+                        
+                 """.trimIndent()
+             )
+             v.forEach {
+                  out.write("   <uri name=\"${it.name}\" uri=\"${it.absolutePath}\"/>\n")
+             }
+             out.write(
+                 """
+                        </group>
+                     </catalog>
+                 """.trimIndent()
+                 )
+         }
+        return cat;
      }
  }

--- a/tools/gradletooling/gradle-plugin/bin/main/net/ivoa/vodml/gradle/plugin/XSLTTransform.kt
+++ b/tools/gradletooling/gradle-plugin/bin/main/net/ivoa/vodml/gradle/plugin/XSLTTransform.kt
@@ -17,7 +17,7 @@ import javax.xml.transform.stream.StreamSource
 /*
  * Created on 27/07/2021 by Paul Harrison (paul.harrison@manchester.ac.uk). 
  */
-abstract class XSLTTransformer( val script: String,  val method: String) {
+ open class XSLTTransformer( val script: String,  val method: String) {
 
     private val logger = LoggerFactory.getLogger(this.javaClass.name)
 

--- a/tools/gradletooling/gradle-plugin/build.gradle.kts
+++ b/tools/gradletooling/gradle-plugin/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "net.ivoa.vo-dml"
-version = "0.3.5"
+version = "0.3.6"
 
 repositories {
     mavenLocal() // FIXME remove this when releasing - just here to pick up local vodsl updates

--- a/tools/gradletooling/gradle-plugin/src/main/kotlin/net/ivoa/vodml/gradle/plugin/VodmlGradlePlugin.kt
+++ b/tools/gradletooling/gradle-plugin/src/main/kotlin/net/ivoa/vodml/gradle/plugin/VodmlGradlePlugin.kt
@@ -128,9 +128,9 @@ class VodmlGradlePlugin: Plugin<Project> {
 
 
         //add the dependencies for JAXB and JPA - using the hibernate implementation
-       listOf("org.javastro.ivoa.vo-dml:vodml-runtime:0.1.1",
+       listOf("org.javastro.ivoa.vo-dml:vodml-runtime:0.1.2",
             "javax.xml.bind:jaxb-api:2.3.1",
-            "org.glassfish.jaxb:jaxb-runtime:2.3.5",
+            "org.glassfish.jaxb:jaxb-runtime:2.3.6",
 //             "org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.10",  // supports JPA 2.2
 //            "org.eclipse.persistence:org.eclipse.persistence.moxy:3.0.2", //alternative Jaxb runtime...
              "org.hibernate:hibernate-core:5.6.5.Final"

--- a/tools/gradletooling/sample/build.gradle.kts
+++ b/tools/gradletooling/sample/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.kotlin.dsl.support.classFilePathCandidatesFor
  * 
  */
 plugins {
-    id("net.ivoa.vo-dml.vodmltools") version "0.3.5"
+    id("net.ivoa.vo-dml.vodmltools") version "0.3.6"
 //    id ("com.diffplug.spotless") version "5.17.1"
 
 }

--- a/tools/gradletooling/sample/src/test/java/org/ivoa/dm/AbstractTest.java
+++ b/tools/gradletooling/sample/src/test/java/org/ivoa/dm/AbstractTest.java
@@ -70,7 +70,7 @@ public class AbstractTest {
           //
             
           //derby
-          props.put("javax.persistence.jdbc.url", "jdbc:derby:memory:"+puname+";create=true");//IMPL differenrt DB for each PU to stop interactions
+          props.put("javax.persistence.jdbc.url", "jdbc:derby:memory:"+puname+";create=true;traceFile=derbytrace.out;traceLevel=-1;");//IMPL differenrt DB for each PU to stop interactions
     //        props.put(PersistenceUnitProperties.JDBC_URL, "jdbc:derby:emerlindb;create=true;traceFile=derbytrace.out;traceLevel=-1;traceDirectory=/tmp");
           props.put("javax.persistence.jdbc.driver", "org.apache.derby.jdbc.EmbeddedDriver");
           // props.put(PersistenceUnitProperties.TARGET_DATABASE, "org.eclipse.persistence.platform.database.DerbyPlatform");

--- a/tools/gradletooling/sample/src/test/java/org/ivoa/dm/notstccoords/CoordsModelTest.java
+++ b/tools/gradletooling/sample/src/test/java/org/ivoa/dm/notstccoords/CoordsModelTest.java
@@ -31,6 +31,8 @@ class CoordsModelTest extends AbstractTest {
     private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory
             .getLogger(CoordsModelTest.class);
     private CelestialPoint pos1;
+    private CoordSys spacesys;
+    private SpaceFrame icrs;
     
     /**
      * @throws java.lang.Exception
@@ -45,7 +47,7 @@ class CoordsModelTest extends AbstractTest {
         
         
         RefLocation ssbc = new StdRefLocation("BARYCENTRE");
-        SpaceFrame icrs = new SpaceFrame().withEquinox("J2000").withRefPosition(ssbc).withSpaceRefFrame("ICRS");
+        icrs = new SpaceFrame().withEquinox("J2000").withRefPosition(ssbc).withSpaceRefFrame("ICRS");
         
         
         RefLocation geocentric = new StdRefLocation("GEOCENTRIC");
@@ -53,7 +55,7 @@ class CoordsModelTest extends AbstractTest {
         
         Unit degree = new Unit("degree");
         PhysicalCoordSpace coordspace = new SphericalCoordSpace();
-        CoordSys spacesys = new SpaceSys(coordspace, icrs);// FIXME withCoordspace missing from the generated code
+        spacesys = new SpaceSys(coordspace, icrs);
         pos1 = new CelestialPoint(new RealQuantity(45.0, degree), new RealQuantity(22.0, degree), spacesys );
         
         
@@ -64,7 +66,9 @@ class CoordsModelTest extends AbstractTest {
         logger.debug("Starting XML test");
         JAXBContext jc = CoordsModel.contextFactory();
         CoordsModel model = new CoordsModel();
+        model.addContent(icrs);
        // model.addContent(pos1); FIXME - need to think about the dtypes should be added to the top level  model object.
+        //TODO actually test
         
     }
 

--- a/tools/gradletooling/sample/src/test/java/org/ivoa/dm/sample/catalog/SourceCatalogueTest.java
+++ b/tools/gradletooling/sample/src/test/java/org/ivoa/dm/sample/catalog/SourceCatalogueTest.java
@@ -146,7 +146,12 @@ class SourceCatalogueTest extends AbstractTest {
         em.persist(sc);
         em.getTransaction().commit();
         Long id = sc.getId();
-        
+
+        //flush any existing entities
+        em.clear();
+        em.getEntityManagerFactory().getCache().evictAll();
+
+        // now read back
         em.getTransaction().begin();
         List<SourceCatalogue> cats = em.createNamedQuery("SourceCatalogue.findById", SourceCatalogue.class)
                 .setParameter("id", id).getResultList();

--- a/tools/xslt/common-binding.xsl
+++ b/tools/xslt/common-binding.xsl
@@ -14,8 +14,7 @@
 
 <xsl:include href="common.xsl"/>
 
-<xsl:key name="ellookup" match="*[vodml-id]" use="concat(ancestor::vo-dml:model/name,':',vodml-id)"/>
-<xsl:key name="memblookup" match="*/*[vodml-id]" use="concat(ancestor::vo-dml:model/name,':',vodml-id)"/>
+<xsl:key name="ellookup" match="//*[vodml-id]" use="concat(ancestor::vo-dml:model/name,':',vodml-id)"/>
 <xsl:key name="maplookup" match="type-mapping[vodml-id]" use="concat(ancestor::model/name,':',vodml-id)"/>
 
   <xsl:param name="targetnamespace_root"/>
@@ -185,7 +184,7 @@ See similar comment in jaxb.xsl:  <xsl:template match="objectType|dataType" mode
         <xsl:value-of select="count($mapping/map:mappedModels/model[name=$modelname]/type-mapping[vodml-id=substring-after($vodml-ref,':')]/java-type) > 0"/>
     </xsl:function>
 
-
+<!-- return the base types for current type - note that this does not return the types in strict hierarchy order (not sure why!) -->
     <xsl:function name="vf:baseTypes" as="element()*">
         <xsl:param name="vodml-ref"/>
         <xsl:choose>
@@ -195,7 +194,7 @@ See similar comment in jaxb.xsl:  <xsl:template match="objectType|dataType" mode
                  </xsl:variable>
                  <xsl:choose>
                      <xsl:when test="$el/extends">
-                         <xsl:sequence select="($models/key('ellookup',$el/extends/vodml-ref),vf:baseTypes($el/extends/vodml-ref))"/>
+                         <xsl:sequence select="($models/key('ellookup',$el/extends/vodml-ref),vf:baseTypes($el/extends/vodml-ref))" />
                      </xsl:when>
                  </xsl:choose>
             </xsl:when>
@@ -205,6 +204,28 @@ See similar comment in jaxb.xsl:  <xsl:template match="objectType|dataType" mode
         </xsl:choose>
 
     </xsl:function>
+
+    <!--just returning the IDs will work in hierarchy order, but then need to use in for-each -->
+    <xsl:function name="vf:baseTypeIds" as="xsd:string*">
+        <xsl:param name="vodml-ref"/>
+        <xsl:choose>
+            <xsl:when test="$models/key('ellookup',$vodml-ref)">
+                <xsl:variable name="el" as="element()">
+                    <xsl:copy-of select="$models/key('ellookup',$vodml-ref)" />
+                </xsl:variable>
+                <xsl:choose>
+                    <xsl:when test="$el/extends">
+                        <xsl:sequence select="($el/extends/vodml-ref,vf:baseTypeIds($el/extends/vodml-ref))"/>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:message terminate="yes">type <xsl:value-of select="$vodml-ref"/> not in considered models for base types</xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
+
+    </xsl:function>
+
 
     <xsl:function name="vf:subTypes" as="element()*">
         <xsl:param name="vodml-ref"/>
@@ -325,18 +346,87 @@ See similar comment in jaxb.xsl:  <xsl:template match="objectType|dataType" mode
 
     </xsl:function>
 
-    <!-- is the attribute subsetted -->
+    <!-- is the attribute subsetted - for it to be truly subsetted it needs to be subtyped too-->
     <xsl:function name="vf:isSubSetted" as="xsd:boolean">
-        <xsl:param name="vodml-ref"/>
+        <xsl:param name="vodml-ref" as="xsd:string"/>
         <xsl:choose>
             <xsl:when test="$models/key('ellookup',$vodml-ref)">
+
                 <!--note that comparison below ignores vodml namespace prefix - slightly dangerous, but only slightly -->
-                <xsl:value-of select="count($models//constraint[ends-with(@xsi:type,':SubsettedRole')]/role[vodml-ref = $vodml-ref])> 0"/>
+                <!-- also note that the datatype checking is just done on not exact equivalence, not if strictly a subtype -->
+                <xsl:value-of select="count($models//*[constraint[ends-with(@xsi:type,':SubsettedRole') and
+                          role[vodml-ref = $vodml-ref] and datatype[vodml-ref != $models/key('ellookup',$vodml-ref)/datatype/vodml-ref ]]])> 0"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:message terminate="yes">type '<xsl:value-of select="$vodml-ref"/>' not in considered models</xsl:message>
             </xsl:otherwise>
         </xsl:choose>
+    </xsl:function>
+
+    <xsl:function name="vf:isSubSettedInHierarchy" as="xsd:boolean">
+        <xsl:param name="type"  as="xsd:string" />
+        <xsl:param name="vodml-ref" as="xsd:string"/>
+        <xsl:variable name="subsets" select="vf:subSettingInSuperHierarchy($type)" as="element()*"/>
+        <xsl:message>is_ssinhier <xsl:value-of select="concat('type=',$type, ' ref=', $vodml-ref)"/>"</xsl:message>
+        <xsl:value-of select="count($subsets[role/vodml-ref = $vodml-ref]) > 0" />
+    </xsl:function>
+
+    <!-- Thiis will return all the subsets found in the hierarchy - will not return subset when it is the same type as the thing it subsets
+     qlso shouuld take care of multiple levels of subsetting...-->
+    <xsl:function name="vf:subSettingInSuperHierarchy" as="element()*">
+        <xsl:param name="vodml-ref" as="xsd:string"/>
+<!--        <xsl:message select="concat('subsetting in hierarchy for=',$vodml-ref)"/>-->
+        <xsl:choose>
+            <xsl:when test="$models/key('ellookup',$vodml-ref)">
+                <!-- have to do this to get types in hierarchical order -->
+                <xsl:variable name="typenames" as="xsd:string*" select="($vodml-ref,vf:baseTypeIds($vodml-ref))"/>
+                <!-- TODO need to worry about the cases where a subset is subset again -->
+                <xsl:variable name="allsubsets" select="$models/key('ellookup',$typenames)/constraint[ends-with(@xsi:type,':SubsettedRole')]" as="element()*"/>
+<!--                <xsl:message>supertypenames=<xsl:value-of select="string-join($typenames,',')"/> subsets=<xsl:value-of select="string-join($allsubsets,',')"/></xsl:message>-->
+
+                    <!-- cannot see hy this will not work - actually because of the context in key() call
+                   <xsl:copy-of select="$allsubsets[datatype/vodml-ref != $models/key('ellookup',role/vodml-ref)/datatype/vodml-ref]"/>
+                    so doing for loop below-->
+                   <xsl:for-each select="$allsubsets">
+                       <xsl:variable name="subsetted" select="$models/key('ellookup',current()/role/vodml-ref)/datatype/vodml-ref"/>
+                       <xsl:if test="current()/datatype/vodml-ref/text() != $subsetted">
+                           <xsl:copy-of select="."/>
+                       </xsl:if>
+                   </xsl:for-each>
+              </xsl:when>
+            <xsl:otherwise>
+                <xsl:message terminate="yes">type '<xsl:value-of select="$vodml-ref"/>' not in considered models</xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
+
+    </xsl:function>
+
+
+    <!-- This will return all the subsets found in the hierarchy - will not return subset when it is the same type as the thing it subsets
+  -->
+    <xsl:function name="vf:subSettingInSubHierarchy" as="element()*">
+        <xsl:param name="vodml-ref" as="xsd:string"/>
+        <!--        <xsl:message select="concat('subsetting in hierarchy for=',$vodml-ref)"/>-->
+        <xsl:choose>
+            <xsl:when test="$models/key('ellookup',$vodml-ref)">
+                <xsl:variable name="allsubsets" select="vf:subTypes($vodml-ref)/constraint[ends-with(@xsi:type,':SubsettedRole')]" as="element()*"/>
+                <!--                <xsl:message>supertypenames=<xsl:value-of select="string-join($typenames,',')"/> subsets=<xsl:value-of select="string-join($allsubsets,',')"/></xsl:message>-->
+
+                <!-- cannot see hy this will not work - actually because of the context in key() call
+               <xsl:copy-of select="$allsubsets[datatype/vodml-ref != $models/key('ellookup',role/vodml-ref)/datatype/vodml-ref]"/>
+                so doing for loop below-->
+                <xsl:for-each select="$allsubsets">
+                    <xsl:variable name="subsetted" select="$models/key('ellookup',current()/role/vodml-ref)/datatype/vodml-ref"/>
+                    <xsl:if test="current()/datatype/vodml-ref/text() != $subsetted">
+                        <xsl:copy-of select="."/>
+                    </xsl:if>
+                </xsl:for-each>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:message terminate="yes">type '<xsl:value-of select="$vodml-ref"/>' not in considered models</xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
+
     </xsl:function>
 
     <xsl:function name="vf:importedModelNames" as="xsd:string*">

--- a/tools/xslt/jaxb.xsl
+++ b/tools/xslt/jaxb.xsl
@@ -26,9 +26,13 @@
 
   @javax.xml.bind.annotation.XmlAccessorType( javax.xml.bind.annotation.XmlAccessType.NONE )  
   @javax.xml.bind.annotation.XmlType( name = "<xsl:value-of select="name"/>")
+  <xsl:variable name="vodml-ref" select="vf:asvodmlref(current())"/>
+  <xsl:if test="vf:hasSubTypes($vodml-ref)">
+  @javax.xml.bind.annotation.XmlSeeAlso({ <xsl:value-of select="string-join(for $s in vf:subTypes($vodml-ref) return concat(vf:QualifiedJavaType(vf:asvodmlref($s)),'.class'),',')"/>  })
+  </xsl:if>
     <xsl:choose>
       <xsl:when test="not(vf:isContained(vf:asvodmlref(.))) and not(@abstract = 'true')">
-    @javax.xml.bind.annotation.XmlRootElement( name = "<xsl:value-of select="name"/>")
+ //   @javax.xml.bind.annotation.XmlElement( name = "<xsl:value-of select="name"/>")
       </xsl:when>
       <xsl:otherwise>
       </xsl:otherwise>

--- a/tools/xslt/jpa.xsl
+++ b/tools/xslt/jpa.xsl
@@ -52,7 +52,7 @@
     @DiscriminatorColumn( name = "<xsl:value-of select="$discriminatorColumnName"/>", discriminatorType = DiscriminatorType.STRING, length = <xsl:value-of select="$discriminatorColumnLength"/>)
     </xsl:if>
     <xsl:if test="$extMod">
-  @DiscriminatorValue( "<xsl:value-of select="$className"/>" ) <!-- TODO decide whether this should be a path - current is just default anyuway-->
+  @DiscriminatorValue( "<xsl:value-of select="$className"/>" ) <!-- TODO decide whether this should be a path - current is just default anyway-->
   </xsl:if>
   @NamedQueries( {
     @NamedQuery( name = "<xsl:value-of select="$className"/>.findById", query = "SELECT o FROM <xsl:value-of select="$className"/> o WHERE o.<xsl:value-of select="$idname"/> = :id")
@@ -60,8 +60,19 @@
 ,     @NamedQuery( name = "<xsl:value-of select="$className"/>.findByName", query = "SELECT o FROM <xsl:value-of select="$className"/> o WHERE o.name = :name")
   </xsl:if>
   } )
- </xsl:template>
+      <xsl:if test="reference[multiplicity/maxOccurs != 1]|composition[multiplicity/maxOccurs != 1]">
+          @NamedEntityGraph(
+             name="<xsl:value-of select="concat($className,'_loadAll')"/>",
+             attributeNodes = {
+               <xsl:for-each select="reference[multiplicity/maxOccurs != 1]|composition[multiplicity/maxOccurs != 1]">
+                   @NamedAttributeNode(value="<xsl:value-of select='name'/>")<xsl:if test="position() != last()">,</xsl:if>
+               </xsl:for-each>
+            }
+          <!-- TODO need to think about subgraphs -->
+          )
+      </xsl:if>
 
+ </xsl:template>
 
 
 
@@ -352,6 +363,7 @@
     @OrderBy( value = "rank" )
         </xsl:if>
     @OneToMany( cascade = CascadeType.ALL, fetch = FetchType.LAZY, targetEntity=<xsl:value-of select="concat(vf:JavaType(datatype/vodml-ref),'.class')" />)
+    @org.hibernate.annotations.Fetch(org.hibernate.annotations.FetchMode.SUBSELECT)
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/tools/xslt/jpa.xsl
+++ b/tools/xslt/jpa.xsl
@@ -199,12 +199,12 @@
 
             </xsl:when>
             <xsl:when test="name($type) = 'enumeration'">
-        <xsl:call-template name="enumPattern">
-          <xsl:with-param name="columnName"><xsl:apply-templates select="." mode="columnName"/></xsl:with-param>
-        </xsl:call-template>
-      </xsl:when>
-          <xsl:when test="name($type) = 'dataType'">
-          <xsl:choose>
+                <xsl:call-template name="enumPattern">
+                   <xsl:with-param name="columnName"><xsl:apply-templates select="." mode="columnName"/></xsl:with-param>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:when test="name($type) = 'dataType'">
+            <xsl:choose>
               <xsl:when test="xsd:int(multiplicity/maxOccurs) = -1">
                   <xsl:variable name="tableName">
                       <xsl:apply-templates select=".." mode="tableName"/><xsl:text>_</xsl:text><xsl:value-of select="$name"/>
@@ -214,37 +214,11 @@
       @Column( name = "<xsl:apply-templates select="." mode="columnName"/>", nullable = <xsl:apply-templates select="." mode="nullable"/> )
               </xsl:when>
               <xsl:otherwise>
-
-          <xsl:choose>
-          <xsl:when test="not(vf:isSubSetted($vodml-ref))">
-      @Embedded
-              <xsl:variable name="attovers" as="xsd:string*">
-              <xsl:for-each select="($type/attribute, vf:baseTypes(vf:asvodmlref($type))/attribute)">
-                  <xsl:variable name="attr" select="."/>
-                  <xsl:variable name="atv" as="xsd:string*">
-                      <xsl:apply-templates select="$models/key('ellookup',current()/datatype/vodml-ref)" mode="attrovercols"><xsl:with-param name="prefix" select="concat($name,'_',name)"/></xsl:apply-templates>
-                  </xsl:variable>
-<!--                  <xsl:message><xsl:value-of select="concat($name,'-',$type/name, ' ', name,' overrides -> ',string-join($atv, ' %%%* '))" /></xsl:message>-->
-                  <xsl:for-each select="$atv">
-                      <xsl:variable name="tmp"> <!-- just to make formatting easier  (otherwise each bit is a string seqmnent, and a lot of quotes!) -->
-                      <xsl:variable name="attsubst">
-                          <xsl:value-of select="string-join(tokenize(.,'_')[position() != 1],'.')"/>
-                      </xsl:variable>
-                      <xsl:variable name="colsubs" select="."/>
-      @AttributeOverride(name="<xsl:value-of select='$attsubst'/>", column = @Column(name="<xsl:value-of select='$colsubs'/>",  nullable =<xsl:apply-templates select="$thisattr" mode="nullable"/> ))
-                      </xsl:variable>
-                      <xsl:value-of select="$tmp"/>
-                  </xsl:for-each>
-              </xsl:for-each>
-              </xsl:variable>
-      @AttributeOverrides( {
-                     <xsl:value-of select="string-join($attovers,concat(',',$cr))"/>
-             })
-                </xsl:when>
-                <xsl:otherwise>//subsetted
-      @Transient
-                </xsl:otherwise>
-               </xsl:choose>
+                  <xsl:call-template name="doEmbeddedJPA">
+                      <xsl:with-param name="name" select="$name"/>
+                      <xsl:with-param name="type" select="$type"/>
+                      <xsl:with-param name="nillable" ><xsl:apply-templates select="$thisattr" mode="nullable"/></xsl:with-param>
+                  </xsl:call-template>
               </xsl:otherwise>
           </xsl:choose>
           </xsl:when>
@@ -253,6 +227,36 @@
         // TODO    [NOT_SUPPORTED_ATTRIBUTE]
             </xsl:otherwise>
         </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="doEmbeddedJPA">
+        <xsl:param name="name"/>
+        <xsl:param name="type"/>
+        <xsl:param name="nillable"/>
+        @Embedded
+        <xsl:variable name="attovers" as="xsd:string*">
+            <xsl:for-each select="($type/attribute, vf:baseTypes(vf:asvodmlref($type))/attribute)">
+                <xsl:variable name="attr" select="."/>
+                <xsl:variable name="atv" as="xsd:string*">
+                    <xsl:apply-templates select="$models/key('ellookup',current()/datatype/vodml-ref)" mode="attrovercols"><xsl:with-param name="prefix" select="concat($name,'_',name)"/></xsl:apply-templates>
+                </xsl:variable>
+                <!--                  <xsl:message><xsl:value-of select="concat($name,'-',$type/name, ' ', name,' overrides -> ',string-join($atv, ' %%%* '))" /></xsl:message>-->
+                <xsl:for-each select="$atv">
+                    <xsl:variable name="tmp"> <!-- just to make formatting easier  (otherwise each bit is a string seqmnent, and a lot of quotes!) -->
+                        <xsl:variable name="attsubst">
+                            <xsl:value-of select="string-join(tokenize(.,'_')[position() != 1],'.')"/>
+                        </xsl:variable>
+                        <xsl:variable name="colsubs" select="."/>
+                        @AttributeOverride(name="<xsl:value-of select='$attsubst'/>", column = @Column(name="<xsl:value-of select='$colsubs'/>",  nullable = <xsl:value-of select='$nillable'/> ))
+                    </xsl:variable>
+                    <xsl:value-of select="$tmp"/>
+                </xsl:for-each>
+            </xsl:for-each>
+        </xsl:variable>
+        @AttributeOverrides( {
+        <xsl:value-of select="string-join($attovers,concat(',',$cr))"/>
+        })
+
     </xsl:template>
 
     <xsl:template match="dataType" mode="attrovercols" as="xsd:string*">


### PR DESCRIPTION
Collections are marked as lazy loading for performance reasons - however there are times that it is desirable to load the full object graph - the easiest way (easier than complex queries) of doing this is to have code generated with the model to walk the object graph which can be executed during the JPA entity manager session after the initial top level query so that JPA will actually load those parts of the object graph